### PR TITLE
[#17] 리액트 쿼리 provider 세팅

### DIFF
--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { ClerkProvider } from '@clerk/nextjs';
 
 import './globals.css';
+import ReactQueryProvider from '@/provider/react-query-provider';
 
 export const metadata: Metadata = {
   title: 'Laugh Log : 웃음으로 가득한 회의록',
@@ -17,7 +18,9 @@ export default function RootLayout({
   return (
     <ClerkProvider>
       <html lang="ko">
-        <body>{children}</body>
+        <body>
+          <ReactQueryProvider>{children}</ReactQueryProvider>
+        </body>
       </html>
     </ClerkProvider>
   );

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "client",
+  "name": "laugh-log",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "client",
+      "name": "laugh-log",
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^4.29.7",
@@ -13,6 +13,7 @@
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.1.5",
+        "@tanstack/react-query": "^5.24.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "firebase": "^10.8.0",
@@ -1671,6 +1672,30 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.24.1.tgz",
+      "integrity": "sha512-DZ6Nx9p7BhjkG50ayJ+MKPgff+lMeol7QYXkvuU5jr2ryW/4ok5eanaS9W5eooA4xN0A/GPHdLGOZGzArgf5Cg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.24.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.24.1.tgz",
+      "integrity": "sha512-4+09JEdO4d6+Gc8Y/g2M/MuxDK5IY0QV8+2wL2304wPKJgJ54cBbULd3nciJ5uvh/as8rrxx6s0mtIwpRuGd1g==",
+      "dependencies": {
+        "@tanstack/query-core": "5.24.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@types/body-parser": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-scroll-area": "^1.0.5",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
+    "@tanstack/react-query": "^5.24.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "firebase": "^10.8.0",

--- a/client/provider/react-query-provider.tsx
+++ b/client/provider/react-query-provider.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren, useState } from 'react';
+
+export default function ReactQueryProvider({ children }: PropsWithChildren) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            staleTime: 60 * 1000
+          }
+        }
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}


### PR DESCRIPTION
close #17 

## Description

<!-- 작업 내용을 적어주세요. -->

리액트 쿼리 사용을 위한 QueryClient provider를 세팅하였습니다.

## 유의할 점 및 ETC (Optional)

<!-- 팀원이 유의해야할 사항을 적어주세요. -->

1. npm ci 하셔야 합니다.
2. [리액트 쿼리 + firestore 사용 예시](https://sugar-gasoline-6bc.notion.site/firestore-10ffdfc30c844d7384efacca1776e6a3?pvs=4)
3. [provider 세팅 참고 리액트 쿼리 공식 문서](https://tanstack.com/query/latest/docs/framework/react/guides/ssr)
