### PR TITLE
[#34] 대시보드 파이어베이스 연동

### DIFF
--- a/client/app/(dashboard)/(routes)/dashboard/page.tsx
+++ b/client/app/(dashboard)/(routes)/dashboard/page.tsx
@@ -15,13 +15,15 @@ const Dashboard = () => {
   }
 
   return (
-    <div className="flex h-full w-full">
-      <Sidebar />
-      <div className="flex h-full w-[calc(100vw-328px)] flex-col justify-between gap-16 overflow-hidden px-14">
-        <StartWithTemplate />
-        <TeamBoard />
+    organization && (
+      <div className="flex h-full w-full">
+        <Sidebar />
+        <div className="flex h-full w-[calc(100vw-328px)] flex-col justify-between gap-16 overflow-hidden px-14">
+          <StartWithTemplate />
+          <TeamBoard organizationId={organization.id} />
+        </div>
       </div>
-    </div>
+    )
   );
 };
 

--- a/client/app/(dashboard)/(routes)/dashboard/page.tsx
+++ b/client/app/(dashboard)/(routes)/dashboard/page.tsx
@@ -19,7 +19,7 @@ const Dashboard = () => {
       <div className="flex h-full w-full">
         <Sidebar />
         <div className="flex h-full w-[calc(100vw-328px)] flex-col justify-between gap-16 overflow-hidden px-14">
-          <StartWithTemplate />
+          <StartWithTemplate organizationId={organization.id} />
           <TeamBoard organizationId={organization.id} />
         </div>
       </div>

--- a/client/app/(dashboard)/(routes)/dashboard/page.tsx
+++ b/client/app/(dashboard)/(routes)/dashboard/page.tsx
@@ -1,8 +1,19 @@
+'use client';
+
+import { useOrganization } from '@clerk/nextjs';
+
+import { addOrganization } from '@/lib/firebaseUtils';
 import Sidebar from '@/app/(dashboard)/_components/sidebar/sidebar';
 import StartWithTemplate from '@/app/(dashboard)/_components/startWithTemplate';
 import TeamBoard from '@/app/(dashboard)/_components/teamBoard';
 
 const Dashboard = () => {
+  const { organization } = useOrganization();
+
+  if (organization) {
+    addOrganization(organization.id);
+  }
+
   return (
     <div className="flex h-full w-full">
       <Sidebar />

--- a/client/app/(dashboard)/_components/MenuItem.tsx
+++ b/client/app/(dashboard)/_components/MenuItem.tsx
@@ -22,12 +22,12 @@ import { renameBoard } from '@/lib/firebaseUtils';
 
 const MenuItem = ({
   boardId,
-  name,
+  boardName,
   header,
   description,
   button
 }: MenuItemProps) => {
-  const [boardName, setBoardName] = useState(name);
+  const [name, setName] = useState(boardName);
   const { organization } = useOrganization();
 
   const handleClick = async () => {
@@ -36,7 +36,7 @@ const MenuItem = ({
         await renameBoard({
           organizationId: organization.id,
           boardId,
-          name: boardName
+          boardName: name
         });
         window.location.reload();
       }
@@ -67,9 +67,9 @@ const MenuItem = ({
         {header === '이름 변경' && (
           <Input
             id="name"
-            defaultValue={name}
+            defaultValue={boardName}
             onChange={e => {
-              setBoardName(e.target.value);
+              setName(e.target.value);
             }}
           />
         )}

--- a/client/app/(dashboard)/_components/MenuItem.tsx
+++ b/client/app/(dashboard)/_components/MenuItem.tsx
@@ -1,0 +1,53 @@
+import { MenuItemProps } from '@/types/dashboard';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger
+} from '@/components/ui/alert-dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+const MenuItem = ({ name, header, description, button }: MenuItemProps) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <button
+          className={cn(
+            'w-full cursor-pointer py-2 text-sm hover:bg-gray-50',
+            header === '보드 삭제' && 'text-[#CD2929]'
+          )}
+        >
+          {header}
+        </button>
+      </AlertDialogTrigger>
+      <AlertDialogContent className="rounded-lg">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex justify-start">
+            {header}
+          </AlertDialogTitle>
+          <AlertDialogDescription className="flex justify-start">
+            {description}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {header === '이름 변경' && <Input id="name" defaultValue={name} />}
+        <AlertDialogFooter className="flex flex-row justify-end gap-2">
+          <AlertDialogCancel asChild className="mt-0">
+            <Button variant="secondary">취소</Button>
+          </AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <Button>{button}</Button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default MenuItem;

--- a/client/app/(dashboard)/_components/MenuItem.tsx
+++ b/client/app/(dashboard)/_components/MenuItem.tsx
@@ -1,3 +1,8 @@
+'use client';
+
+import { useState } from 'react';
+import { useOrganization } from '@clerk/nextjs';
+
 import { MenuItemProps } from '@/types/dashboard';
 import {
   AlertDialog,
@@ -13,8 +18,31 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+import { renameBoard } from '@/lib/firebaseUtils';
 
-const MenuItem = ({ name, header, description, button }: MenuItemProps) => {
+const MenuItem = ({
+  boardId,
+  name,
+  header,
+  description,
+  button
+}: MenuItemProps) => {
+  const [boardName, setBoardName] = useState(name);
+  const { organization } = useOrganization();
+
+  const handleClick = async () => {
+    if (organization) {
+      if (header === '이름 변경') {
+        await renameBoard({
+          organizationId: organization.id,
+          boardId,
+          name: boardName
+        });
+        window.location.reload();
+      }
+    }
+  };
+
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
@@ -36,13 +64,21 @@ const MenuItem = ({ name, header, description, button }: MenuItemProps) => {
             {description}
           </AlertDialogDescription>
         </AlertDialogHeader>
-        {header === '이름 변경' && <Input id="name" defaultValue={name} />}
+        {header === '이름 변경' && (
+          <Input
+            id="name"
+            defaultValue={name}
+            onChange={e => {
+              setBoardName(e.target.value);
+            }}
+          />
+        )}
         <AlertDialogFooter className="flex flex-row justify-end gap-2">
           <AlertDialogCancel asChild className="mt-0">
             <Button variant="secondary">취소</Button>
           </AlertDialogCancel>
           <AlertDialogAction asChild>
-            <Button>{button}</Button>
+            <Button onClick={handleClick}>{button}</Button>
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/client/app/(dashboard)/_components/MenuItem.tsx
+++ b/client/app/(dashboard)/_components/MenuItem.tsx
@@ -18,7 +18,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { renameBoard } from '@/lib/firebaseUtils';
+import { renameBoard, deleteBoard } from '@/lib/firebaseUtils';
 
 const MenuItem = ({
   boardId,
@@ -38,8 +38,10 @@ const MenuItem = ({
           boardId,
           boardName: name
         });
-        window.location.reload();
+      } else {
+        await deleteBoard({ organizationId: organization.id, boardId });
       }
+      window.location.reload();
     }
   };
 

--- a/client/app/(dashboard)/_components/boardItem.tsx
+++ b/client/app/(dashboard)/_components/boardItem.tsx
@@ -1,28 +1,32 @@
+import Link from 'next/link';
 import Image from 'next/image';
 
+import { BoardItemProps } from '@/types/dashboard';
 import BoardMenu from './boardMenu';
 
-const BoardItem = () => {
+const BoardItem = ({ id, name, date }: BoardItemProps) => {
   return (
-    <div className="aspect-[300/222] ">
-      <div className="relative h-[80%] w-full rounded-md  bg-gray-200">
-        <BoardMenu>
-          <button className="absolute right-0 top-0">
-            <Image
-              src="/board-more.svg"
-              alt="more button"
-              width={64}
-              height={64}
-              className="object-fit hover:cursor-pointer"
-            />
-          </button>
-        </BoardMenu>
+    <Link href={`/workspace/${id}`}>
+      <div className="aspect-[300/222] ">
+        <div className="relative h-[80%] w-full rounded-md  bg-gray-200">
+          <BoardMenu>
+            <button className="absolute right-0 top-0">
+              <Image
+                src="/board-more.svg"
+                alt="more button"
+                width={64}
+                height={64}
+                className="object-fit hover:cursor-pointer"
+              />
+            </button>
+          </BoardMenu>
+        </div>
+        <div className="flex w-full flex-col justify-center">
+          <span className="body2m mt-1 font-normal">{name}</span>
+          <span className="caption1m font-normal text-gray600">{date}</span>
+        </div>
       </div>
-      <div className="flex w-full flex-col justify-center">
-        <span className="body2m mt-1 font-normal">Untitled</span>
-        <span className="caption1m font-normal text-gray600">어제 편집됨</span>
-      </div>
-    </div>
+    </Link>
   );
 };
 

--- a/client/app/(dashboard)/_components/boardItem.tsx
+++ b/client/app/(dashboard)/_components/boardItem.tsx
@@ -4,12 +4,12 @@ import Image from 'next/image';
 import { BoardItemProps } from '@/types/dashboard';
 import BoardMenu from './boardMenu';
 
-const BoardItem = ({ id, name, date }: BoardItemProps) => {
+const BoardItem = ({ boardId, boardName, date }: BoardItemProps) => {
   return (
-    <Link href={`/workspace/${id}`}>
+    <Link href={`/workspace/${boardId}`}>
       <div className="aspect-[300/222] ">
         <div className="relative h-[80%] w-full rounded-md  bg-gray-200">
-          <BoardMenu id={id} name={name}>
+          <BoardMenu boardId={boardId} boardName={boardName}>
             <button className="absolute right-0 top-0">
               <Image
                 src="/board-more.svg"
@@ -22,7 +22,7 @@ const BoardItem = ({ id, name, date }: BoardItemProps) => {
           </BoardMenu>
         </div>
         <div className="flex w-full flex-col justify-center">
-          <span className="body2m mt-1 font-normal">{name}</span>
+          <span className="body2m mt-1 font-normal">{boardName}</span>
           <span className="caption1m font-normal text-gray600">{date}</span>
         </div>
       </div>

--- a/client/app/(dashboard)/_components/boardItem.tsx
+++ b/client/app/(dashboard)/_components/boardItem.tsx
@@ -9,7 +9,7 @@ const BoardItem = ({ id, name, date }: BoardItemProps) => {
     <Link href={`/workspace/${id}`}>
       <div className="aspect-[300/222] ">
         <div className="relative h-[80%] w-full rounded-md  bg-gray-200">
-          <BoardMenu name={name}>
+          <BoardMenu id={id} name={name}>
             <button className="absolute right-0 top-0">
               <Image
                 src="/board-more.svg"

--- a/client/app/(dashboard)/_components/boardItem.tsx
+++ b/client/app/(dashboard)/_components/boardItem.tsx
@@ -9,7 +9,7 @@ const BoardItem = ({ id, name, date }: BoardItemProps) => {
     <Link href={`/workspace/${id}`}>
       <div className="aspect-[300/222] ">
         <div className="relative h-[80%] w-full rounded-md  bg-gray-200">
-          <BoardMenu>
+          <BoardMenu name={name}>
             <button className="absolute right-0 top-0">
               <Image
                 src="/board-more.svg"

--- a/client/app/(dashboard)/_components/boardList.tsx
+++ b/client/app/(dashboard)/_components/boardList.tsx
@@ -3,13 +3,13 @@ import BoardItem from './boardItem';
 
 const BoardList = ({ boardList }: BoardListProps) => {
   return (
-    <div className="laptop:grid-cols-3 desktop:grid-cols-3 tablet:grid-cols-1 grid grid-cols-1 gap-12 overflow-auto">
+    <div className="grid grid-cols-1 gap-12 overflow-auto tablet:grid-cols-1 laptop:grid-cols-3 desktop:grid-cols-3">
       {boardList.map(board => {
         return (
           <BoardItem
             key={board.id}
-            id={board.id}
-            name={board.name}
+            boardId={board.id}
+            boardName={board.name}
             date={board.date}
           />
         );

--- a/client/app/(dashboard)/_components/boardList.tsx
+++ b/client/app/(dashboard)/_components/boardList.tsx
@@ -1,9 +1,19 @@
+import { BoardListProps } from '@/types/dashboard';
 import BoardItem from './boardItem';
 
-const BoardList = () => {
+const BoardList = ({ boardList }: BoardListProps) => {
   return (
     <div className="laptop:grid-cols-3 desktop:grid-cols-3 tablet:grid-cols-1 grid grid-cols-1 gap-12 overflow-auto">
-      <BoardItem />
+      {boardList.map(board => {
+        return (
+          <BoardItem
+            key={board.id}
+            id={board.id}
+            name={board.name}
+            date={board.date}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/client/app/(dashboard)/_components/boardMenu.tsx
+++ b/client/app/(dashboard)/_components/boardMenu.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import MenuItem from './MenuItem';
 
-const BoardMenu = ({ children, name }: BoardMenuProps) => {
+const BoardMenu = ({ children, id, name }: BoardMenuProps) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
@@ -16,12 +16,14 @@ const BoardMenu = ({ children, name }: BoardMenuProps) => {
         className="flex flex-col"
       >
         <MenuItem
+          boardId={id}
           name={name}
           header="이름 변경"
           description="변경할 이름을 입력해주세요."
           button="수정"
         />
         <MenuItem
+          boardId={id}
           name={name}
           header="보드 삭제"
           description="보드를 삭제하시겠습니까?"

--- a/client/app/(dashboard)/_components/boardMenu.tsx
+++ b/client/app/(dashboard)/_components/boardMenu.tsx
@@ -2,21 +2,31 @@ import { BoardMenuProps } from '@/types/dashboard';
 import {
   DropdownMenu,
   DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem
+  DropdownMenuContent
 } from '@/components/ui/dropdown-menu';
+import MenuItem from './MenuItem';
 
-const BoardMenu = ({ children }: BoardMenuProps) => {
+const BoardMenu = ({ children, name }: BoardMenuProps) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
-      <DropdownMenuContent side="right">
-        <DropdownMenuItem className="cursor-pointer">
-          이름 변경
-        </DropdownMenuItem>
-        <DropdownMenuItem className="cursor-pointer text-[#CD2929]">
-          보드 삭제
-        </DropdownMenuItem>
+      <DropdownMenuContent
+        side="right"
+        onClick={e => e.stopPropagation()}
+        className="flex flex-col"
+      >
+        <MenuItem
+          name={name}
+          header="이름 변경"
+          description="변경할 이름을 입력해주세요."
+          button="수정"
+        />
+        <MenuItem
+          name={name}
+          header="보드 삭제"
+          description="보드를 삭제하시겠습니까?"
+          button="삭제"
+        />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/client/app/(dashboard)/_components/boardMenu.tsx
+++ b/client/app/(dashboard)/_components/boardMenu.tsx
@@ -6,7 +6,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import MenuItem from './MenuItem';
 
-const BoardMenu = ({ children, id, name }: BoardMenuProps) => {
+const BoardMenu = ({ children, boardId, boardName }: BoardMenuProps) => {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
@@ -16,15 +16,15 @@ const BoardMenu = ({ children, id, name }: BoardMenuProps) => {
         className="flex flex-col"
       >
         <MenuItem
-          boardId={id}
-          name={name}
+          boardId={boardId}
+          boardName={boardName}
           header="이름 변경"
           description="변경할 이름을 입력해주세요."
           button="수정"
         />
         <MenuItem
-          boardId={id}
-          name={name}
+          boardId={boardId}
+          boardName={boardName}
           header="보드 삭제"
           description="보드를 삭제하시겠습니까?"
           button="삭제"

--- a/client/app/(dashboard)/_components/emptyBoards.tsx
+++ b/client/app/(dashboard)/_components/emptyBoards.tsx
@@ -1,4 +1,6 @@
-const EmptyBoards = () => {
+import { EmptyBoardsProps } from '@/types/dashboard';
+
+const EmptyBoards = ({ onClick }: EmptyBoardsProps) => {
   return (
     <div className="flex h-[222px] w-full shrink-0 flex-col items-center justify-center gap-6 overflow-y-scroll rounded bg-coral200 p-4">
       <span className="text-center">
@@ -6,7 +8,10 @@ const EmptyBoards = () => {
         <br />
         새로운 보드를 생성해보세요!
       </span>
-      <button className="body3b h-[46px] w-[149px] rounded-xl bg-coral600 text-white hover:cursor-pointer">
+      <button
+        className="body3b h-[46px] w-[149px] rounded-xl bg-coral600 text-white hover:cursor-pointer"
+        onClick={onClick}
+      >
         새로운 보드 만들기
       </button>
     </div>

--- a/client/app/(dashboard)/_components/emptyBoards.tsx
+++ b/client/app/(dashboard)/_components/emptyBoards.tsx
@@ -1,6 +1,16 @@
+import { useRouter } from 'next/navigation';
+
+import { addBoard } from '@/lib/firebaseUtils';
 import { EmptyBoardsProps } from '@/types/dashboard';
 
-const EmptyBoards = ({ onClick }: EmptyBoardsProps) => {
+const EmptyBoards = ({ organizationId, onClick }: EmptyBoardsProps) => {
+  const router = useRouter();
+
+  const handleClick = async () => {
+    const boardId = await addBoard(organizationId);
+    router.push(`/workspace/${boardId}`);
+  };
+
   return (
     <div className="flex h-[222px] w-full shrink-0 flex-col items-center justify-center gap-6 overflow-y-scroll rounded bg-coral200 p-4">
       <span className="text-center">
@@ -10,7 +20,7 @@ const EmptyBoards = ({ onClick }: EmptyBoardsProps) => {
       </span>
       <button
         className="body3b h-[46px] w-[149px] rounded-xl bg-coral600 text-white hover:cursor-pointer"
-        onClick={onClick}
+        onClick={handleClick}
       >
         새로운 보드 만들기
       </button>

--- a/client/app/(dashboard)/_components/startWithTemplate.tsx
+++ b/client/app/(dashboard)/_components/startWithTemplate.tsx
@@ -1,7 +1,8 @@
+import { StartWithTemplateProps } from '@/types/dashboard';
 import Subtitle from './subtitle';
 import TemplateItem from './templateItem';
 
-const StartWithTemplate = () => {
+const StartWithTemplate = ({ organizationId }: StartWithTemplateProps) => {
   const template = [
     { name: '새로운 보드', imageUrl: '/new-board.svg' },
     { name: '회의록', imageUrl: '/new-board.svg' },
@@ -15,7 +16,12 @@ const StartWithTemplate = () => {
       <Subtitle>템플릿으로 시작하기</Subtitle>
       <div className="h-45 flex w-full shrink-0 items-center gap-[24px] overflow-y-scroll rounded bg-coral200 p-4">
         {template.map(({ name, imageUrl }) => (
-          <TemplateItem key={name} name={name} imageUrl={imageUrl} />
+          <TemplateItem
+            key={name}
+            organizationId={organizationId}
+            name={name}
+            imageUrl={imageUrl}
+          />
         ))}
       </div>
     </main>

--- a/client/app/(dashboard)/_components/teamBoard.tsx
+++ b/client/app/(dashboard)/_components/teamBoard.tsx
@@ -9,14 +9,14 @@ import BoardList from './boardList';
 const TeamBoard = ({ organizationId }: TeamBoardProps) => {
   const [boardList, setBoardList] = useState<BoardListType>();
 
-  const fetchBoardList = async () => {
-    const data = await getBoardList(organizationId);
-    setBoardList(data);
-  };
-
   useEffect(() => {
+    const fetchBoardList = async () => {
+      const data = await getBoardList(organizationId);
+      setBoardList(data);
+    };
+
     fetchBoardList();
-  });
+  }, [organizationId]);
 
   const onClick = async () => {
     await addBoard(organizationId);

--- a/client/app/(dashboard)/_components/teamBoard.tsx
+++ b/client/app/(dashboard)/_components/teamBoard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 
 import { TeamBoardProps, BoardListType } from '@/types/dashboard';
-import { getBoardList } from '@/lib/firebaseUtils';
+import { addBoard, getBoardList } from '@/lib/firebaseUtils';
 import Subtitle from './subtitle';
 import EmptyBoards from './emptyBoards';
 import BoardList from './boardList';
@@ -9,14 +9,18 @@ import BoardList from './boardList';
 const TeamBoard = ({ organizationId }: TeamBoardProps) => {
   const [boardList, setBoardList] = useState<BoardListType>();
 
-  useEffect(() => {
-    const fetchBoardList = async () => {
-      const data = await getBoardList(organizationId);
-      setBoardList(data);
-    };
+  const fetchBoardList = async () => {
+    const data = await getBoardList(organizationId);
+    setBoardList(data);
+  };
 
+  useEffect(() => {
     fetchBoardList();
-  }, [organizationId]);
+  });
+
+  const onClick = async () => {
+    await addBoard(organizationId);
+  };
 
   return (
     <div className="flex h-[calc(100vh-332px)] w-full flex-col gap-6">
@@ -24,7 +28,7 @@ const TeamBoard = ({ organizationId }: TeamBoardProps) => {
       {boardList?.length ? (
         <BoardList boardList={boardList} />
       ) : (
-        <EmptyBoards />
+        <EmptyBoards onClick={onClick} />
       )}
     </div>
   );

--- a/client/app/(dashboard)/_components/teamBoard.tsx
+++ b/client/app/(dashboard)/_components/teamBoard.tsx
@@ -28,7 +28,7 @@ const TeamBoard = ({ organizationId }: TeamBoardProps) => {
       {boardList?.length ? (
         <BoardList boardList={boardList} />
       ) : (
-        <EmptyBoards onClick={onClick} />
+        <EmptyBoards organizationId={organizationId} onClick={onClick} />
       )}
     </div>
   );

--- a/client/app/(dashboard)/_components/teamBoard.tsx
+++ b/client/app/(dashboard)/_components/teamBoard.tsx
@@ -1,13 +1,31 @@
+import { useState, useEffect } from 'react';
+
+import { TeamBoardProps, BoardListType } from '@/types/dashboard';
+import { getBoardList } from '@/lib/firebaseUtils';
 import Subtitle from './subtitle';
 import EmptyBoards from './emptyBoards';
 import BoardList from './boardList';
 
-const TeamBoard = () => {
+const TeamBoard = ({ organizationId }: TeamBoardProps) => {
+  const [boardList, setBoardList] = useState<BoardListType>();
+
+  useEffect(() => {
+    const fetchBoardList = async () => {
+      const data = await getBoardList(organizationId);
+      setBoardList(data);
+    };
+
+    fetchBoardList();
+  }, [organizationId]);
+
   return (
     <div className="flex h-[calc(100vh-332px)] w-full flex-col gap-6">
       <Subtitle>팀 보드</Subtitle>
-      {/* <EmptyBoards /> */}
-      <BoardList />
+      {boardList?.length ? (
+        <BoardList boardList={boardList} />
+      ) : (
+        <EmptyBoards />
+      )}
     </div>
   );
 };

--- a/client/app/(dashboard)/_components/templateItem.tsx
+++ b/client/app/(dashboard)/_components/templateItem.tsx
@@ -4,20 +4,19 @@ import { Plus } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 
-interface TemplateItemProps {
-  name: string;
-  imageUrl: string;
-}
+import { TemplateItemProps } from '@/types/dashboard';
+import { addBoard } from '@/lib/firebaseUtils';
 
-const TemplateItem = ({ name, imageUrl }: TemplateItemProps) => {
+const TemplateItem = ({
+  organizationId,
+  name,
+  imageUrl
+}: TemplateItemProps) => {
   const router = useRouter();
 
-  const clickToGenerateHandler = () => {
-    /*
-      대충 새로운 workspacet생성해서 id 생성
-    */
-
-    router.push(`/workspace/id`);
+  const clickToGenerateHandler = async () => {
+    const boardId = await addBoard(organizationId);
+    router.push(`/workspace/${boardId}`);
   };
 
   return (

--- a/client/components/ui/alert-dialog.tsx
+++ b/client/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/client/components/ui/alert-dialog.tsx
+++ b/client/components/ui/alert-dialog.tsx
@@ -1,16 +1,16 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/components/ui/button';
 
-const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialog = AlertDialogPrimitive.Root;
 
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = AlertDialogPrimitive.Portal
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -18,14 +18,14 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
     ref={ref}
   />
-))
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
@@ -36,14 +36,14 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        'sm:rounded-lg fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]',
         className
       )}
       {...props}
     />
   </AlertDialogPortal>
-))
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({
   className,
@@ -51,13 +51,13 @@ const AlertDialogHeader = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
+      'sm:text-left flex flex-col space-y-2 text-center',
       className
     )}
     {...props}
   />
-)
-AlertDialogHeader.displayName = "AlertDialogHeader"
+);
+AlertDialogHeader.displayName = 'AlertDialogHeader';
 
 const AlertDialogFooter = ({
   className,
@@ -65,13 +65,13 @@ const AlertDialogFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      'sm:flex-row sm:justify-end sm:space-x-2 flex flex-col-reverse',
       className
     )}
     {...props}
   />
-)
-AlertDialogFooter.displayName = "AlertDialogFooter"
+);
+AlertDialogFooter.displayName = 'AlertDialogFooter';
 
 const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
@@ -79,11 +79,11 @@ const AlertDialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold", className)}
+    className={cn('text-lg font-semibold', className)}
     {...props}
   />
-))
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
@@ -91,12 +91,12 @@ const AlertDialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
+));
 AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName
+  AlertDialogPrimitive.Description.displayName;
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
@@ -107,8 +107,8 @@ const AlertDialogAction = React.forwardRef<
     className={cn(buttonVariants(), className)}
     {...props}
   />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
@@ -117,14 +117,14 @@ const AlertDialogCancel = React.forwardRef<
   <AlertDialogPrimitive.Cancel
     ref={ref}
     className={cn(
-      buttonVariants({ variant: "outline" }),
-      "mt-2 sm:mt-0",
+      buttonVariants({ variant: 'secondary' }),
+      'sm:mt-0 mt-2',
       className
     )}
     {...props}
   />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
@@ -137,5 +137,5 @@ export {
   AlertDialogTitle,
   AlertDialogDescription,
   AlertDialogAction,
-  AlertDialogCancel,
-}
+  AlertDialogCancel
+};

--- a/client/components/ui/input.tsx
+++ b/client/components/ui/input.tsx
@@ -1,0 +1,25 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+export { Input }

--- a/client/lib/firebaseUtils.ts
+++ b/client/lib/firebaseUtils.ts
@@ -1,0 +1,8 @@
+import { setDoc, doc } from 'firebase/firestore';
+
+import { db } from '@/firebase/app';
+
+export const addOrganization = async (organizationId: string) => {
+  const teamRef = doc(db, 'team', organizationId);
+  await setDoc(teamRef, {}, { merge: true });
+};

--- a/client/lib/firebaseUtils.ts
+++ b/client/lib/firebaseUtils.ts
@@ -3,6 +3,7 @@ import {
   getDocs,
   addDoc,
   updateDoc,
+  deleteDoc,
   doc,
   collection
 } from 'firebase/firestore';
@@ -47,4 +48,14 @@ export const renameBoard = async ({
 }) => {
   const docRef = doc(db, 'team', organizationId, 'board', boardId);
   await updateDoc(docRef, { name: boardName });
+};
+
+export const deleteBoard = async ({
+  organizationId,
+  boardId
+}: {
+  organizationId: string;
+  boardId: string;
+}) => {
+  await deleteDoc(doc(db, 'team', organizationId, 'board', boardId));
 };

--- a/client/lib/firebaseUtils.ts
+++ b/client/lib/firebaseUtils.ts
@@ -1,4 +1,11 @@
-import { setDoc, getDocs, addDoc, doc, collection } from 'firebase/firestore';
+import {
+  setDoc,
+  getDocs,
+  addDoc,
+  updateDoc,
+  doc,
+  collection
+} from 'firebase/firestore';
 import { format } from 'date-fns';
 
 import { db } from '@/firebase/app';
@@ -27,4 +34,17 @@ export const addBoard = async (organizationId: string) => {
     date: format(new Date(), 'yyyy.MM.dd')
   });
   return docRef.id;
+};
+
+export const renameBoard = async ({
+  organizationId,
+  boardId,
+  name
+}: {
+  organizationId: string;
+  boardId: string;
+  name: string;
+}) => {
+  const docRef = doc(db, 'team', organizationId, 'board', boardId);
+  await updateDoc(docRef, { name: name });
 };

--- a/client/lib/firebaseUtils.ts
+++ b/client/lib/firebaseUtils.ts
@@ -39,12 +39,12 @@ export const addBoard = async (organizationId: string) => {
 export const renameBoard = async ({
   organizationId,
   boardId,
-  name
+  boardName
 }: {
   organizationId: string;
   boardId: string;
-  name: string;
+  boardName: string;
 }) => {
   const docRef = doc(db, 'team', organizationId, 'board', boardId);
-  await updateDoc(docRef, { name: name });
+  await updateDoc(docRef, { name: boardName });
 };

--- a/client/lib/firebaseUtils.ts
+++ b/client/lib/firebaseUtils.ts
@@ -1,8 +1,21 @@
-import { setDoc, doc } from 'firebase/firestore';
+import { setDoc, getDocs, doc, collection } from 'firebase/firestore';
 
 import { db } from '@/firebase/app';
 
 export const addOrganization = async (organizationId: string) => {
   const teamRef = doc(db, 'team', organizationId);
   await setDoc(teamRef, {}, { merge: true });
+};
+
+export const getBoardList = async (organizationId: string) => {
+  const querySnapshot = await getDocs(
+    collection(db, 'team', organizationId, 'board')
+  );
+  return querySnapshot.docs.map(doc => {
+    return {
+      id: doc.id,
+      name: doc.data().name,
+      date: doc.data().date
+    };
+  });
 };

--- a/client/lib/firebaseUtils.ts
+++ b/client/lib/firebaseUtils.ts
@@ -1,4 +1,5 @@
-import { setDoc, getDocs, doc, collection } from 'firebase/firestore';
+import { setDoc, getDocs, addDoc, doc, collection } from 'firebase/firestore';
+import { format } from 'date-fns';
 
 import { db } from '@/firebase/app';
 
@@ -18,4 +19,12 @@ export const getBoardList = async (organizationId: string) => {
       date: doc.data().date
     };
   });
+};
+
+export const addBoard = async (organizationId: string) => {
+  const docRef = await addDoc(collection(db, 'team', organizationId, 'board'), {
+    name: 'Untitled',
+    date: format(new Date(), 'yyyy.MM.dd')
+  });
+  return docRef.id;
 };

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.0",
         "clerk": "^0.8.3",
         "clsx": "^2.1.0",
+        "date-fns": "^3.3.1",
         "firebase": "^10.8.0",
         "lucide-react": "^0.338.0",
         "next": "^13.5.6",
@@ -3062,6 +3063,15 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.3.1.tgz",
+      "integrity": "sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^4.29.7",
+        "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
+        "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-scroll-area": "^1.0.5",
         "@radix-ui/react-slot": "^1.0.2",
         "@radix-ui/react-toast": "^1.1.5",
@@ -1247,6 +1249,34 @@
         "@babel/runtime": "^7.13.10"
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.0.5.tgz",
+      "integrity": "sha512-OrVIOcZL0tl6xibeuGt5/+UxoT2N27KCFOPjFyfXMnchxSHZ/OW7cCX2nGlIYJrbHK/fczPcFzAwvNBB6XBNMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.0.3.tgz",
@@ -1495,6 +1525,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.0.2.tgz",
+      "integrity": "sha512-N5ehvlM7qoTLx7nWPodsPYPgMzA5WM8zZChQg8nyFJKnDO5WHdba1vv5/H6IO5LtJMfD2Q3wh1qHFGNtK0w3bQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "class-variance-authority": "^0.7.0",
     "clerk": "^0.8.3",
     "clsx": "^2.1.0",
+    "date-fns": "^3.3.1",
     "firebase": "^10.8.0",
     "lucide-react": "^0.338.0",
     "next": "^13.5.6",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^4.29.7",
+    "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-scroll-area": "^1.0.5",

--- a/client/types/dashboard.ts
+++ b/client/types/dashboard.ts
@@ -34,4 +34,12 @@ export type BoardItemProps = {
 
 export type BoardMenuProps = {
   children: React.ReactNode;
+  name: string;
+};
+
+export type MenuItemProps = {
+  name: string;
+  header: string;
+  description: string;
+  button: string;
 };

--- a/client/types/dashboard.ts
+++ b/client/types/dashboard.ts
@@ -34,10 +34,12 @@ export type BoardItemProps = {
 
 export type BoardMenuProps = {
   children: React.ReactNode;
+  id: string;
   name: string;
 };
 
 export type MenuItemProps = {
+  boardId: string;
   name: string;
   header: string;
   description: string;

--- a/client/types/dashboard.ts
+++ b/client/types/dashboard.ts
@@ -27,20 +27,20 @@ export type BoardListProps = {
 };
 
 export type BoardItemProps = {
-  id: string;
-  name: string;
+  boardId: string;
+  boardName: string;
   date: string;
 };
 
 export type BoardMenuProps = {
   children: React.ReactNode;
-  id: string;
-  name: string;
+  boardId: string;
+  boardName: string;
 };
 
 export type MenuItemProps = {
   boardId: string;
-  name: string;
+  boardName: string;
   header: string;
   description: string;
   button: string;

--- a/client/types/dashboard.ts
+++ b/client/types/dashboard.ts
@@ -1,5 +1,19 @@
+export type StartWithTemplateProps = {
+  organizationId: string;
+};
+
+export type TemplateItemProps = {
+  organizationId: string;
+  name: string;
+  imageUrl: string;
+};
+
 export type TeamBoardProps = {
   organizationId: string;
+};
+
+export type EmptyBoardsProps = {
+  onClick: () => void;
 };
 
 export type BoardListType = {

--- a/client/types/dashboard.ts
+++ b/client/types/dashboard.ts
@@ -1,7 +1,3 @@
-export type DashboardLayoutProps = {
-  children: React.ReactNode;
-};
-
 export type BoardMenuProps = {
   children: React.ReactNode;
 };

--- a/client/types/dashboard.ts
+++ b/client/types/dashboard.ts
@@ -13,6 +13,7 @@ export type TeamBoardProps = {
 };
 
 export type EmptyBoardsProps = {
+  organizationId: string;
   onClick: () => void;
 };
 

--- a/client/types/dashboard.ts
+++ b/client/types/dashboard.ts
@@ -1,3 +1,23 @@
+export type TeamBoardProps = {
+  organizationId: string;
+};
+
+export type BoardListType = {
+  id: string;
+  name: string;
+  date: string;
+}[];
+
+export type BoardListProps = {
+  boardList: BoardListType;
+};
+
+export type BoardItemProps = {
+  id: string;
+  name: string;
+  date: string;
+};
+
 export type BoardMenuProps = {
   children: React.ReactNode;
 };


### PR DESCRIPTION
close #34 

## Description
- [x] 팀 생성
- [x] 보드 목록 불러오기
- [x] 보드 생성
- [x] 보드 이름 변경
- [x] 보드 삭제

## 유의할 점 및 ETC (Optional)
npm i 해주세요 !
보드 생성 시 간헐적으로 메인 홈페이지로 돌아가는 경우가 있는데 언제 왜 발생하는지 알 수가 없어서 에러 핸들링은 아직 못했습니닷..
그리고 현재는 보드 생성/이름 변경/삭제 후 페이지 전체를 리로드하고 있는데,
컴포넌트 단위로 리렌더링을 하는 방식이 더 깔끔할 것 같아서 이 부분도 좀 더 고민해보겠습니다.

## 스크린샷 (Optional)
### 보드 생성
https://github.com/LaughLog/laugh-log/assets/155057856/6969a9ec-ddff-447a-8e2d-6d4cbb1efc8f

### 보드 이름 변경
https://github.com/LaughLog/laugh-log/assets/155057856/87a52e4f-f3d1-43cb-b5eb-1a646d739d1d

### 보드 삭제
https://github.com/LaughLog/laugh-log/assets/155057856/2af69d16-3d86-4871-9fff-482ec7579d7f