### PR TITLE
[#57] 텍스트 에디터 socket event 연결 및 구현

### DIFF
--- a/client/app/(textEditor)/(routes)/text-editor/page.tsx
+++ b/client/app/(textEditor)/(routes)/text-editor/page.tsx
@@ -1,21 +1,22 @@
-import InitialBlocks from '../../_components/initialBlocks';
+import InitSocket from '../../_components/initSocket';
 
 const TextEditor = async () => {
   return (
     <section className="mx-auto my-0 w-2/3">
-      <InitialBlocks>
+      <InitSocket>
         <article className="mx-0 my-8 border-l-4 border-solid border-l-[#0f2e53] py-1 pl-2 pr-4">
           <h1 role="img" aria-label="greetings" className="pr-2">
             Hallo! 👋
           </h1>
           <p>
             <span className="rounded-s bg-orange-200 p-0.5">Enter</span> 키를
-            통해 새로운 블록을 생성해 보세요.{' '}
-            <span className="rounded-sm bg-orange-200 p-0.5">/</span> 기능은
-            향후 추가될 예정입니다.
+            통해 새로운 블록을 생성해 보세요.
+            <br />
+            <span className="rounded-sm bg-orange-200 p-0.5">/</span> 키를 통해
+            다양한 블록을 사용해 보세요.
           </p>
         </article>
-      </InitialBlocks>
+      </InitSocket>
     </section>
   );
 };

--- a/client/app/(textEditor)/_components/editableBlock.tsx
+++ b/client/app/(textEditor)/_components/editableBlock.tsx
@@ -143,7 +143,7 @@ const EditableBlock = ({
   // content 변경 핸들러
   const onChangeHandler = (e: ContentEditableEvent) => {
     const value = e.target.value;
-
+    setContent(value);
     // 디바운스로 정확한 입력값 전달하기
     if (debounceTimer.current) {
       clearTimeout(debounceTimer.current);

--- a/client/app/(textEditor)/_components/editableBlock.tsx
+++ b/client/app/(textEditor)/_components/editableBlock.tsx
@@ -281,12 +281,6 @@ const EditableBlock = ({
     // 한글 key일 때 2번 입력되는 오류 방지
     if (e.nativeEvent.isComposing) return;
 
-    /*
-    const newContent = e.target.value;
-    startTransition(() => setContent(newContent));
-    socket.emit('set-block-content', blockId, newContent);
-    */
-
     // "/" 입력 시 새로운 menu open
     if (e.key === CMD_KEY.SLASH) {
       openMenuHandler();

--- a/client/app/(textEditor)/_components/editableBlock.tsx
+++ b/client/app/(textEditor)/_components/editableBlock.tsx
@@ -1,58 +1,159 @@
 'use client';
 
-import { useRef, useState, KeyboardEvent, startTransition } from 'react';
+import { useRef, useState, useEffect } from 'react';
 import ContentEditable, { ContentEditableEvent } from 'react-contenteditable';
 
+import { socket } from '@/socket/socket';
 import SelectMenu from './selectMenu';
-import { EditableBlockProps } from '@/types/textEditor';
-import { setCaretTo } from '@/lib/utils';
-
-const CMD_KEY = '/';
+import { setCaretTo, uid } from '@/lib/utils';
+import { CMD_KEY, SET_TIME } from '@/constants/textEditor';
+import {
+  EditableBlockProps,
+  BlockContentHandler,
+  AddBlocksHandler,
+  DeleteBlocksHandler,
+  ChangeTagHandler,
+  KeyEventHandler,
+  MenuSelectionHandler
+} from '@/types/textEditor';
 
 const EditableBlock = ({
-  block,
-  addBlock,
-  deleteBlock,
+  blockId,
+  blockContent,
+  blockTag,
   setBlocks
 }: EditableBlockProps) => {
-  const [html, setHtml] = useState(block.html);
-  const [tag, setTag] = useState(block.tag);
+  const [content, setContent] = useState(blockContent);
+  const [tag, setTag] = useState(blockTag);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
-
-  // ContentEditable 컴포넌트에 대한 참조
   const contentEditable = useRef<HTMLInputElement>(null);
 
-  // HTML 변경 핸들러
-  const onChangeHandler = (e: ContentEditableEvent) => {
-    setHtml(e.target.value);
+  // socket events
+  useEffect(() => {
+    const addBlocksHandler: AddBlocksHandler = (id, previousHtml, newBlock) => {
+      if (blockId === id) {
+        setContent(previousHtml);
+        setBlocks(pre => {
+          const updatedBlocks = [...pre];
+          let index = -1;
 
-    setBlocks(prevBlocks => {
-      const updatedBlocks = [...prevBlocks];
-      let index = -1;
+          // 해당 블록의 인덱스를 찾을 때까지 반복
+          while (index === -1) {
+            index = updatedBlocks.findIndex(block => block.id === id);
+          }
 
-      // 해당 블록의 인덱스를 찾을 때까지 반복
-      while (index === -1) {
-        index = updatedBlocks.findIndex(
-          block => block.id === contentEditable.current?.id
-        );
+          updatedBlocks.splice(index + 1, 0, newBlock);
+
+          updatedBlocks[index].content = previousHtml;
+
+          return updatedBlocks;
+        });
       }
+    };
 
-      updatedBlocks[index] = {
-        ...updatedBlocks[index],
-        html: e.target.value
-      };
+    const deleteBlocksHandler: DeleteBlocksHandler = (
+      deleteBlockId,
+      previousBlockId,
+      newContent
+    ) => {
+      if (blockId === previousBlockId) {
+        if (newContent !== '') {
+          setContent(newContent);
+        }
 
-      return updatedBlocks;
-    });
+        setBlocks(pre => {
+          const updatedBlocks = [
+            ...pre.filter(block => block.id !== deleteBlockId)
+          ];
+
+          if (newContent !== '') {
+            let index = -1;
+
+            while (index === -1) {
+              index = updatedBlocks.findIndex(
+                block => block.id === previousBlockId
+              );
+            }
+
+            updatedBlocks[index] = {
+              ...updatedBlocks[index],
+              content: newContent
+            };
+          }
+
+          return updatedBlocks;
+        });
+      }
+    };
+
+    const blockContentHandler: BlockContentHandler = (id, value) => {
+      if (blockId === id) {
+        setContent(value);
+
+        setBlocks(pre => {
+          const updatedBlocks = [...pre];
+          let index = -1;
+
+          while (index === -1) {
+            index = updatedBlocks.findIndex(block => block.id === id);
+          }
+
+          updatedBlocks[index] = {
+            ...updatedBlocks[index],
+            content: value
+          };
+
+          return updatedBlocks;
+        });
+      }
+    };
+
+    const changeTagHandler: ChangeTagHandler = (id, tag) => {
+      if (blockId === id) {
+        menuSelectionHandler(tag);
+        setBlocks(pre => {
+          const updatedBlocks = [...pre];
+          let index = -1;
+
+          while (index === -1) {
+            index = updatedBlocks.findIndex(block => block.id === id);
+          }
+
+          updatedBlocks[index] = {
+            ...updatedBlocks[index],
+            tag
+          };
+
+          return updatedBlocks;
+        });
+      }
+    };
+
+    socket.on('add-blocks', addBlocksHandler);
+    socket.on('delete-blocks', deleteBlocksHandler);
+    socket.on('set-block-content', blockContentHandler);
+    socket.on('set-block-tag', changeTagHandler);
+
+    return () => {
+      socket.off('add-blocks', addBlocksHandler);
+      socket.off('delete-blocks', deleteBlocksHandler);
+      socket.off('set-block-content', blockContentHandler);
+      socket.off('set-block-tag', changeTagHandler);
+    };
+  }, []);
+
+  // content 변경 핸들러
+  const onChangeHandler = (e: ContentEditableEvent) => {
+    setContent(e.target.value);
+    socket.emit('set-block-content', blockId, e.target.value);
   };
 
-  // 키 다운 이벤트 핸들러
-  const onKeyDownHandler = (e: KeyboardEvent<HTMLInputElement>) => {
+  const onKeyDownHandler: KeyEventHandler = e => {
     // 한글 key일 때 2번 입력되는 오류 방지
     if (e.nativeEvent.isComposing) return;
 
     // 새로운 블록 추가
-    if (e.key === 'Enter') {
+    if (e.key === CMD_KEY.ENTER) {
       // 새로운 박스 생성 전 menu close
       setIsMenuOpen(false);
 
@@ -68,15 +169,26 @@ const EditableBlock = ({
         const newHtml = content?.substring(anchorIndex!);
 
         if (previousHtml !== undefined && newHtml !== undefined) {
-          setHtml(previousHtml);
-          addBlock({ id: block.id, ref: element, previousHtml, newHtml });
+          const newBlock = { id: uid(), content: newHtml, tag: 'p' };
+
+          socket.emit('add-blocks', blockId, previousHtml, newBlock);
+
+          setTimeout(() => {
+            (element?.nextElementSibling as HTMLInputElement).focus();
+          }, SET_TIME.FOCUS_NEXT_EL);
         }
       }
     }
 
     // 블록 삭제
-    if (e.key === 'Backspace') {
-      if (window.getSelection()?.anchorOffset === 0) {
+    if (e.key === CMD_KEY.BACKSPACE) {
+      if (
+        window.getSelection()?.anchorOffset === 0 &&
+        !(
+          (e.nativeEvent.target as HTMLInputElement)?.innerHTML === '<br>' ||
+          !(e.nativeEvent.target as HTMLInputElement)?.innerHTML
+        )
+      ) {
         const element = contentEditable.current;
         const content = element?.innerHTML;
         const previousBlock = element?.previousElementSibling as
@@ -87,13 +199,14 @@ const EditableBlock = ({
           previousBlock !== undefined &&
           previousBlock.tagName !== 'ARTICLE'
         ) {
-          if (content) deleteBlock({ id: block.id, previousBlock, content });
+          const newContent = previousBlock.innerHTML + content;
+
+          if (content)
+            socket.emit('delete-blocks', blockId, previousBlock.id, newContent);
 
           setTimeout(() => {
             // 이전 블록의 마지막 커서 위치 기억
             const offset = previousBlock.innerHTML.length;
-
-            setHtml((previousBlock.innerHTML += content));
 
             // 이전 블록의 마지막 커서 위치로 focus
             if (offset) {
@@ -107,26 +220,30 @@ const EditableBlock = ({
             } else {
               setCaretTo('start', previousBlock);
             }
-          }, 350);
+          }, SET_TIME.FOCUS_PREVIOUS_EL);
         }
       }
 
       if (
-        (e.nativeEvent.target as HTMLInputElement)?.innerHTML === '<br>' ||
-        !(e.nativeEvent.target as HTMLInputElement)?.innerHTML
+        window.getSelection()?.anchorOffset === 0 &&
+        ((e.nativeEvent.target as HTMLInputElement)?.innerHTML === '<br>' ||
+          !(e.nativeEvent.target as HTMLInputElement)?.innerHTML)
       ) {
+        e.preventDefault();
+
         const previousBlock = contentEditable.current
           ?.previousElementSibling as HTMLInputElement | undefined;
 
         // article 태그를 기준으로 가장 첫 번째 block 유지
         if (previousBlock && previousBlock.tagName !== 'ARTICLE') {
-          deleteBlock({ id: block.id, previousBlock, content: '' });
+          socket.emit('delete-blocks', blockId, previousBlock.id, '');
+          setCaretTo('end', previousBlock);
         }
       }
     }
 
     // 블록 이동
-    if (e.key === 'ArrowUp') {
+    if (e.key === CMD_KEY.ARROW_UP) {
       e.preventDefault();
 
       const currentBlock = contentEditable.current;
@@ -140,7 +257,7 @@ const EditableBlock = ({
       }
     }
 
-    if (e.key === 'ArrowDown') {
+    if (e.key === CMD_KEY.ARROW_DOWN) {
       e.preventDefault();
 
       const currentBlock = contentEditable.current;
@@ -154,22 +271,19 @@ const EditableBlock = ({
     }
   };
 
-  // 키 업 이벤트 핸들러
-  const onKeyUpHandler = (e: KeyboardEvent<HTMLDivElement>) => {
+  const onKeyUpHandler: KeyEventHandler = e => {
     // "/" 입력 시 새로운 menu open
-    if (e.key === CMD_KEY) {
+    if (e.key === CMD_KEY.SLASH) {
       openMenuHandler();
     }
   };
 
-  // 메뉴 open 핸들러
   const openMenuHandler = () => {
     setIsMenuOpen(true);
     document.addEventListener('click', closeMenuHandler);
     contentEditable.current?.blur();
   };
 
-  // 메뉴 close 핸들러
   const closeMenuHandler = () => {
     document.removeEventListener('click', closeMenuHandler);
 
@@ -178,10 +292,10 @@ const EditableBlock = ({
         setCaretTo('end', contentEditable.current);
         setIsMenuOpen(false);
       }
-    });
+    }, SET_TIME.FOCUS_CURRENT_EL);
   };
 
-  const menuSelectionHandler = (selectedTag: string) => {
+  const menuSelectionHandler: MenuSelectionHandler = selectedTag => {
     setTag(selectedTag);
     closeMenuHandler();
   };
@@ -190,16 +304,16 @@ const EditableBlock = ({
     <>
       {isMenuOpen && (
         <SelectMenu
-          setHtml={setHtml}
-          onSelect={menuSelectionHandler}
+          id={blockId}
+          setContent={setContent}
           onClose={closeMenuHandler}
         />
       )}
       <ContentEditable
-        id={block.id}
+        id={blockId}
         className="mx-0 my-1 rounded bg-slate-50 p-2 hover:outline-[#f5f6fb]"
         innerRef={contentEditable}
-        html={html}
+        html={content}
         tagName={tag}
         onChange={onChangeHandler}
         onKeyDown={onKeyDownHandler}

--- a/client/app/(textEditor)/_components/editablePage.tsx
+++ b/client/app/(textEditor)/_components/editablePage.tsx
@@ -1,29 +1,18 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { doc, updateDoc } from 'firebase/firestore';
 
-import EditableBlock from './editableBlock';
 import { db } from '@/firebase/app';
-import { uid } from '@/lib/utils';
-import {
-  AddBlockHandlerProps,
-  DeleteBlockHandlerProps,
-  Block
-} from '@/types/textEditor';
-import { useMutation } from '@tanstack/react-query';
+import EditableBlock from './editableBlock';
+import { SET_TIME } from '@/constants/textEditor';
+import { Block, EditablePageProps } from '@/types/textEditor';
 
-const EditablePage = ({
-  initialBlocks,
-  boardId
-}: {
-  initialBlocks: Block[];
-  boardId: string;
-}) => {
+const EditablePage = ({ initialBlocks, boardId }: EditablePageProps) => {
   const [blocks, setBlocks] = useState(initialBlocks);
 
-  // Update Server Blocks
-  // useMutation과 디바운싱을 활용한 서버 상태 업데이트 비용 감소 ~
+  // useMutation + 디바운싱 (서버 상태 업데이트 비용 감소 ~
   const [timer, setTimer] = useState<null | NodeJS.Timeout>(null);
   const { mutate: updateServerBlocks } = useMutation({
     mutationFn: (updatedBlocks: Block[]) =>
@@ -34,70 +23,18 @@ const EditablePage = ({
     if (timer) {
       clearTimeout(timer);
     }
-
-    setTimer(setTimeout(() => updateServerBlocks(blocks), 200));
+    setTimer(setTimeout(() => updateServerBlocks(blocks), SET_TIME.DEBOUNCE));
   }, [blocks]);
-  // ~ 비용 감소
-
-  // 새로운 블록 추가 핸들러
-  const addBlockHandler = (currentBlock: AddBlockHandlerProps) => {
-    const newBlock = { id: uid(), html: currentBlock.newHtml, tag: 'p' };
-
-    // 이전 블록 배열에 새로운 블록을 추가한 후 상태 업데이트
-    setBlocks(prevBlocks => {
-      const updatedBlocks = [...prevBlocks];
-      let index = -1;
-
-      // 해당 블록의 인덱스를 찾을 때까지 반복
-      while (index === -1) {
-        index = updatedBlocks.findIndex(block => block.id === currentBlock.id);
-      }
-
-      updatedBlocks.splice(index + 1, 0, newBlock);
-      updatedBlocks[index].html = currentBlock.previousHtml;
-
-      return updatedBlocks;
-    });
-
-    // 블록이 추가된 후 새로운 블록 포커스
-    setTimeout(() => {
-      (currentBlock.ref?.nextElementSibling as HTMLInputElement).focus();
-    });
-  };
-
-  // 블록 삭제 핸들러
-  const deleteBlockHandler = async (currentBlock: DeleteBlockHandlerProps) => {
-    // 해당 블록을 제외한 blocks로 상태 업데이트
-    setBlocks(prevBlocks => {
-      const updatedBlocks = [
-        ...prevBlocks.filter(block => block.id !== currentBlock.id)
-      ];
-      let index = -1;
-
-      // 해당 블록의 인덱스를 찾을 때까지 반복
-      while (index === -1) {
-        index = updatedBlocks.findIndex(
-          block => block.id === currentBlock.previousBlock.id
-        );
-      }
-
-      updatedBlocks[index] = {
-        ...updatedBlocks[index],
-        html: updatedBlocks[index].html + currentBlock.content
-      };
-
-      return updatedBlocks;
-    });
-  };
+  // ~ 비용 감소)
 
   return (
     <>
       {blocks.map(block => (
         <EditableBlock
           key={block.id}
-          block={block}
-          addBlock={addBlockHandler}
-          deleteBlock={deleteBlockHandler}
+          blockId={block.id}
+          blockContent={block.content}
+          blockTag={block.tag}
           setBlocks={setBlocks}
         />
       ))}
@@ -105,5 +42,4 @@ const EditablePage = ({
   );
 };
 
-// EditablePage 컴포넌트를 내보냅니다.
 export default EditablePage;

--- a/client/app/(textEditor)/_components/initBlocks.tsx
+++ b/client/app/(textEditor)/_components/initBlocks.tsx
@@ -1,24 +1,19 @@
 'use client';
 
-import useGetBlocks from '@/hook/queries/useGetBlocks';
-import EditablePage from './editablePage';
 import { doc } from 'firebase/firestore';
+
 import { db } from '@/firebase/app';
+import EditablePage from './editablePage';
+import useGetBlocks from '@/hook/queries/useGetBlocks';
 import { Block } from '@/types/textEditor';
 
-const InitialBlocks = ({ children }: { children: React.ReactNode }) => {
-  // Read Server Blocks
+const InitBlocks = () => {
   const boardId = 'test1'; // 향후 query string으로 대체
   const textEditorRef = doc(db, 'text-editor', boardId);
   const { data } = useGetBlocks(textEditorRef);
   const initialBlocks: Block[] = data.data()?.updatedBlocks;
 
-  return (
-    <>
-      {children}
-      <EditablePage initialBlocks={initialBlocks} boardId={boardId} />
-    </>
-  );
+  return <EditablePage initialBlocks={initialBlocks} boardId={boardId} />;
 };
 
-export default InitialBlocks;
+export default InitBlocks;

--- a/client/app/(textEditor)/_components/initSocket.tsx
+++ b/client/app/(textEditor)/_components/initSocket.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Suspense, useEffect, useState } from 'react';
+
+import { socket } from '@/socket/socket';
+import InitBlocks from './initBlocks';
+import Loading from '../(routes)/text-editor/loading';
+import { InitSocketProps } from '@/types/textEditor';
+
+const InitSocket = ({ children }: InitSocketProps) => {
+  const [isConnected, setIsConnected] = useState(false);
+
+  useEffect(() => {
+    if (!isConnected) {
+      socket.connect();
+      setIsConnected(true);
+    }
+  }, []);
+
+  return (
+    <>
+      {children}
+      <Suspense fallback={<Loading />}>
+        {isConnected && <InitBlocks />}
+      </Suspense>
+    </>
+  );
+};
+
+export default InitSocket;

--- a/client/constants/textEditor.ts
+++ b/client/constants/textEditor.ts
@@ -1,0 +1,43 @@
+// enum vs. const enum (https://inpa.tistory.com/entry/TS-%F0%9F%93%98-%ED%83%80%EC%9E%85%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8-enum-%EC%A0%95%EB%A6%AC)
+export const enum SET_TIME {
+  DEBOUNCE = 200,
+  FOCUS_CURRENT_EL = 50,
+  FOCUS_PREVIOUS_EL = 350,
+  FOCUS_NEXT_EL = 50
+}
+
+export const enum CMD_KEY {
+  SLASH = '/',
+  ENTER = 'Enter',
+  BACKSPACE = 'Backspace',
+  ARROW_UP = 'ArrowUp',
+  ARROW_DOWN = 'ArrowDown',
+  TAB = 'Tab'
+}
+
+export const enum MENU {
+  HEIGHT = 150
+}
+
+export const MENU_ITEMS = [
+  {
+    id: 'page-title',
+    tag: 'h1',
+    label: '제목 1'
+  },
+  {
+    id: 'heading',
+    tag: 'h2',
+    label: '제목 2'
+  },
+  {
+    id: 'subheading',
+    tag: 'h3',
+    label: '제목 3'
+  },
+  {
+    id: 'paragraph',
+    tag: 'p',
+    label: '텍스트'
+  }
+];

--- a/client/socket/socket.ts
+++ b/client/socket/socket.ts
@@ -1,0 +1,7 @@
+import { io } from 'socket.io-client';
+
+// "undefined" means the URL will be computed from the `window.location` object
+const URL =
+  process.env.NODE_ENV === 'production' ? '' : 'http://localhost:8080';
+
+export const socket = io(URL);

--- a/client/types/textEditor.ts
+++ b/client/types/textEditor.ts
@@ -1,35 +1,61 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, KeyboardEvent } from 'react';
 
 export type Block = {
   id: string;
-  html: string;
+  content: string;
   tag: string;
 };
+
+// InitSocket
+
+export type InitSocketProps = { children: React.ReactNode };
 
 // EditablePage
 
 export type EditablePageProps = {
   initialBlocks: Block[];
-};
-
-export type AddBlockHandlerProps = {
-  id: string;
-  ref: HTMLInputElement | null;
-  previousHtml: string;
-  newHtml: string;
-};
-
-export type DeleteBlockHandlerProps = {
-  id: string;
-  previousBlock: HTMLInputElement;
-  content: string;
+  boardId: string;
 };
 
 // EditableBlock
 
 export type EditableBlockProps = {
-  block: Block;
-  addBlock: (currentBlock: AddBlockHandlerProps) => void;
-  deleteBlock: (currentBlock: DeleteBlockHandlerProps) => void;
+  blockId: string;
+  blockContent: string;
+  blockTag: string;
   setBlocks: Dispatch<SetStateAction<Block[]>>;
 };
+
+export type AddBlocksHandler = (
+  id: string,
+  previousHtml: string,
+  newBlock: {
+    id: string;
+    content: string;
+    tag: string;
+  }
+) => void;
+
+export type DeleteBlocksHandler = (
+  deleteBlockId: string,
+  previousBlockId: string,
+  newContent: string
+) => void;
+
+export type BlockContentHandler = (id: string, value: string) => void;
+
+export type ChangeTagHandler = (id: string, tag: string) => void;
+
+export type KeyEventHandler = (e: KeyboardEvent<HTMLInputElement>) => void;
+
+export type MenuSelectionHandler = (selectedTag: string) => void;
+
+// SelectMenu
+
+export type SelectMenuProps = {
+  id: string;
+  setContent: Dispatch<SetStateAction<string>>;
+  onClose: () => void;
+};
+
+export type MenuKeyDownHandler = (e: globalThis.KeyboardEvent) => void;

--- a/server/index.js
+++ b/server/index.js
@@ -41,12 +41,6 @@ io.on("connection", (socket) => {
     io.emit("set-block-tag", id, tag);
   });
 
-  socket.on("draw-line", ({ prevPoint, currentPoint, color }) => {
-    socket.broadcast.emit("draw-line", { prevPoint, currentPoint, color });
-  });
-
-  socket.on("clear", () => io.emit("clear"));
-
   socket.on("disconnect", () => {
     console.log("disconnected");
   });

--- a/server/index.js
+++ b/server/index.js
@@ -25,8 +25,20 @@ const io = new Server(server, {
 io.on("connection", (socket) => {
   console.log("We are connected");
 
-  socket.on("chat", (chat) => {
-    io.emit("chat", chat);
+  socket.on("add-blocks", (blockId, previousHtml, newBlock) => {
+    io.emit("add-blocks", blockId, previousHtml, newBlock);
+  });
+
+  socket.on("delete-blocks", (blockId, previousBlockID, newContent) => {
+    io.emit("delete-blocks", blockId, previousBlockID, newContent);
+  });
+
+  socket.on("set-block-content", (id, value) => {
+    io.emit("set-block-content", id, value);
+  });
+
+  socket.on("set-block-tag", (id, tag) => {
+    io.emit("set-block-tag", id, tag);
   });
 
   socket.on("draw-line", ({ prevPoint, currentPoint, color }) => {


### PR DESCRIPTION
close #57 

## 스크린샷 (Optional)

https://github.com/LaughLog/laugh-log/assets/101972330/6bb0bb8a-a69c-4ec4-a350-ffeb6b72a6bd

## Description

<!-- 작업 내용을 적어주세요. -->

### 목차
1. init socket
2. 실시간 block 추가 및 삭제
3. 실시간 block content 편집

---
### 1. init socket
[러닝 포인트]
- express로 socket 서버 만들기
- react에서 socket 연결하기

[구현 사항]
[참고 문헌: Socket.is 공식 문서, How to use with React](https://socket.io/how-to/use-with-react)

1. express Socket.is Server 생성
```js
const express = require("express");
const http = require("http");
const Server = require("socket.io").Server;
const app = express();
const server = http.createServer(app);

const io = new Server(server, {
  cors: {
    origin: "*",
  },
});

// ...

server.listen(8080, () => console.log("Listening to port 8080"));

```

2. Server Socket 연결 및 비연결 이벤트 생성
```tsx

// ...

io.on("connection", (socket) => {
  console.log("We are connected");

  // ...

  socket.on("disconnect", () => {
    console.log("disconnected");
  });
});

server.listen(8080, () => console.log("Listening to port 8080"));

```

3. const socket 생성
```tsx
// socket/socket.ts

import { io } from 'socket.io-client';

const URL =
  process.env.NODE_ENV === 'production' ? '' : 'http://localhost:8080';

export const socket = io(URL);
```

4. const socket 텍스트 에디터 페이지로 전달하여 연결하기
```tsx
'use client';

// ...

import { socket } from '@/socket/socket';

// ...

const InitSocket = ({ children }: InitSocketProps) => {
  const [isConnected, setIsConnected] = useState(false);

  // isConnected 상태가 false일 때 socket 항상 연결
  useEffect(() => {
    if (!isConnected) {
      socket.connect();
      setIsConnected(true);
    }
  }, []);

  // isConnected 가 true 일 때만 InitBlocks 컴포넌트 보이기
  return (
    <>
      {children}
      {isConnected && <InitBlocks />}
    </>
  );
};

export default InitSocket;
```

### 2. 실시간 block 추가 및 삭제
[러닝 포인트]
- socket으로 실시간 문자열 데이터 전송
- client에서 socket events 등록 및 제거
- react에서 상태 실시간으로 공유하기

[구현 사항]
1. socket server에 'add-blocks' socket event 등록
```tsx
io.on("connection", (socket) => {
  // ...

  socket.on("add-blocks", (blockId, previousHtml, newBlock) => {
    // 서버에서 데이터 처리 후 emit으로 client에 다시 전달
    io.emit("add-blocks", blockId, previousHtml, newBlock);
  });

  // ...

});
```

2. client에 'add-blocks' socket event 등록
<img width="770" alt="image" src="https://github.com/LaughLog/laugh-log/assets/101972330/a8200dd4-feba-4306-9b2c-dd041974f184">

- useEffect의 빈배열을 사용하여 사용자가 페이지 접속 시 최초 한 번만 socket event를 등록한다.
- 다른 사용자에게 새로운 block 상태를 보여주기 위해서는 event에 등록한 handler안에서 useState의 setter 함수를 호출한다.

3. 'add-blocks' socket event 동작 구현
-  시용자의 'Enter' 입력 감지 시 onKeyDownHandler 실행

```tsx
// 새로운 id를 가지는 block 생성
const newBlock = { id: uid(), content: newHtml, tag: 'p' };

// 'add-blocks' socket event emit (방출, 트리거)
socket.emit('add-blocks', blockId, previousHtml, newBlock);

// 새로운 block이 추가된 후 사용자 커서를 새로운 block으로 focus
setTimeout(() => {
  (element?.nextElementSibling as HTMLInputElement).focus();
}, SET_TIME.FOCUS_NEXT_EL);
```

- 자세한 로직은 다르지만 삭제 또한 구현 과정이 동일합니다.

### 3. 실시간 block content 편집
[러닝 포인트]
- 디바운스를 활용하여 socket에 정확한 문자열 전달하기

[구현 사항]
1. socket server에 'set-block-content' socket event 등록
```tsx
io.on("connection", (socket) => {
  // ...

  socket.on("set-block-content", (id, value) => {
    // 서버에서 데이터 처리 후 emit으로 client에 다시 전달
    io.emit("set-block-content", id, value);
  });

  // ...

});
```

2. client에 'set-block-content' socket event 등록
```tsx

// ...

useEffect(() => {

     // ...

    const blockContentHandler: BlockContentHandler = (id, value) => {
      if (blockId === id) {
        setContent(value);
        setBlocks(pre => {
          const updatedBlocks = [...pre];
          const index = updatedBlocks.findIndex(block => block.id === id);

          if (index !== -1) {
            updatedBlocks[index] = {
              ...updatedBlocks[index],
              content: value
            };
          }

          return updatedBlocks;
        });
      }
    };

    socket.on('set-block-content', blockContentHandler);

    return () => {

     // ...

      socket.off('set-block-content', blockContentHandler);

     // ...

    };
  }, []);

// ...

```
- useEffect의 빈배열을 사용하여 사용자가 페이지 접속 시 최초 한 번만 socket event를 등록한다.

4. 'set-block-content' socket event 동작 구현 (디바운스로 올바른 content 전달하기)
- onChange 이벤트로 사용자의 입력을 가져온다.
- 이때 socket event handler에 단순히 setter 함수를 전달하면 아래와 같은 문제가 발생한다.

https://github.com/LaughLog/laugh-log/assets/101972330/c7f9a16d-096c-42e3-8a9e-111a15bbdf15


- 사용자의 입력 속도보다 socket server를 거쳐 blocks content 상태가 업데이트 되는 속도가 느려 올바른 content 전달이 어렵다.
- 이를 해결하기 위해 입력자의 content는 바로 업데이트해주면서, 상대에게 보여지는 content는 어느정도 key value들을 입력을 받은 후 업데이트 하는 방식인 디바운스를 사용한다.

```tsx
  const onChangeHandler = (e: ContentEditableEvent) => {
  const value = e.target.value;
  setContent(value);
  // 디바운스로 정확한 입력값 전달하기
  if (debounceTimer.current) {
    clearTimeout(debounceTimer.current);
  }

  debounceTimer.current = setTimeout(() => {
    socket.emit('set-block-content', blockId, value);
  }, SET_TIME.DEBOUNCE);
};
```

- 결과

https://github.com/LaughLog/laugh-log/assets/101972330/38f596fe-d066-4f2c-8441-2a7c22527927
